### PR TITLE
Port to python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ This version does not use or need CMake - this means it will build on windows
 only with the MSVC compilers for python
 (https://www.microsoft.com/en-us/download/details.aspx?id=44266)
 """
+from __future__ import print_function
 
 import glob
 import os
@@ -104,7 +105,7 @@ class SDistCommand(sdist):
 
         for filename in result:
             outpath = os.path.join("./src/", os.path.basename(filename))
-            print "%s -> %s" % (filename, outpath)
+            print("%s -> %s" % (filename, outpath))
             shutil.copy(filename, outpath)
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools.command.build_ext import build_ext
 
 
 SYSTEM = platform.system().lower()
-VERSION = '3.0.4.post2'
+VERSION = '3.0.4.post3'
 
 
 def get_sources():


### PR DESCRIPTION
This is an attempt to make this repo Python 3 compatible.

I just ran `futurize` over the `setup.py` and that was enough, capstone already supports Python3.

I'm not familiar with the procedure, or naming convention for `Pypi`.

Please let me know if i have to increase the version number somewhere.